### PR TITLE
make provider a configuration

### DIFF
--- a/codecli/commands/clone.py
+++ b/codecli/commands/clone.py
@@ -1,11 +1,13 @@
-from codecli.utils import check_call, repo_git_url, cd, merge_config
+from codecli.utils import (check_call, repo_git_url, cd, merge_config,
+                           get_default_provider)
 
 
 def populate_argument_parser(parser):
     parser.add_argument('repo', help="url or name of repo [e.g. dae]")
     parser.add_argument('dir', nargs='?', help="directory to clone to")
-    parser.add_argument('-p', '--provider', default='code',
-                        help="Git service provider code/github. [code]")
+    provider = get_default_provider()
+    parser.add_argument('-p', '--provider', default=provider,
+                        help="Git service provider code/github. [%s]" % provider)
 
 
 def main(args):

--- a/codecli/commands/fork.py
+++ b/codecli/commands/fork.py
@@ -1,5 +1,6 @@
 from codecli.utils import (check_call, repo_git_url, cd, merge_config,
-                           print_log, get_code_username, log_error)
+                           print_log, get_code_username, get_default_provider,
+                           log_error)
 
 
 def populate_argument_parser(parser):
@@ -13,8 +14,9 @@ def populate_argument_parser(parser):
         parser.add_argument('origin',
                             help="name of my fork [e.g.  hongqn/dae]")
     parser.add_argument('dir', nargs='?', help="directory to clone")
-    parser.add_argument('-p', '--provider', default='code',
-                        help="Git service provider code/github. [code]")
+    provider = get_default_provider()
+    parser.add_argument('-p', '--provider', default=provider,
+                        help="Git service provider code/github. [%s]" % provider)
 
 
 def main(args):

--- a/codecli/utils.py
+++ b/codecli/utils.py
@@ -157,6 +157,11 @@ def get_code_username():
     return user_name
 
 
+def get_default_provider():
+    provider = get_config('provider.name')
+    return provider or 'code'
+
+
 def getoutput(cmd, **kwargs):
     stdout, stderr = Popen(cmd, stdout=PIPE, stderr=open(os.devnull, 'w'),
                            **kwargs).communicate()


### PR DESCRIPTION
For those who have no access to [code](http://code.dapps.douban.com/), they may have this two lines in their `.codecli.conf`:
```
[provider]
    name = github
```